### PR TITLE
Feat/update-queue

### DIFF
--- a/src/api/SignallingServer.js
+++ b/src/api/SignallingServer.js
@@ -5,6 +5,7 @@ class SignallingServer {
         this.loginMessage = undefined;
         this.offerMessage = undefined;
         this.answerMessage = undefined;
+        this.updatedQueueMessage = undefined;
     }
 
 
@@ -36,6 +37,7 @@ class SignallingServer {
                     this.answerMessage = parsedMessage;
                     break;
                 case "update-queue":
+                    this.updatedQueueMessage = parsedMessage;
                     break;
                 case "leave":
                     break;
@@ -127,6 +129,10 @@ class SignallingServer {
         this._send({
             type: "user-start-game"
         });
+    }
+
+    getUpdatedQueue() {
+        return this.updatedQueueMessage.updatedQueue
     }
 }
 

--- a/src/components/Battle.js
+++ b/src/components/Battle.js
@@ -20,7 +20,7 @@ function Battle(props) {
         if (!location.username) {
             window.alert("Please log in before playing a game!");
             history.push("/");
-        } else {
+        } else if (history.purpose === "playing") {
             webRTC.setVideoCallback(setVideoStream);
         }
     }, []);

--- a/src/components/Battle.js
+++ b/src/components/Battle.js
@@ -20,7 +20,7 @@ function Battle(props) {
         if (!location.username) {
             window.alert("Please log in before playing a game!");
             history.push("/");
-        } else if (history.purpose === "playing") {
+        } else if (location.purpose === "playing") {
             webRTC.setVideoCallback(setVideoStream);
         }
     }, []);

--- a/src/components/GameSelect.js
+++ b/src/components/GameSelect.js
@@ -31,10 +31,13 @@ function GameSelect(props) {
                                 webRTC.setAnswer(answer);
                                 signallingServer.startGame();
 
+                                location.push({
+                                    purpose: "playing"
+                                })
+
                                 history.push({
                                     pathname: "/game-select/battle",
                                     username: location.username,
-                                    purpose: "playing"
                                 });
                             })
                             .catch((error) => {
@@ -46,13 +49,15 @@ function GameSelect(props) {
                     });
             })
             .catch((error) => {
-                // TODO Handle no robot found
+                // Handle no robot found
+                location.push({
+                    purpose: "waiting"
+                })
+
                 history.push({
                     pathname: "/game-select/battle",
                     username: location.username,
-                    purpose:  "waiting"
                 });
-            })
     }
 
     const goToShooting = () => {

--- a/src/components/GameSelect.js
+++ b/src/components/GameSelect.js
@@ -33,7 +33,8 @@ function GameSelect(props) {
 
                                 history.push({
                                     pathname: "/game-select/battle",
-                                    username: location.username
+                                    username: location.username,
+                                    purpose: "playing"
                                 });
                             })
                             .catch((error) => {
@@ -46,7 +47,11 @@ function GameSelect(props) {
             })
             .catch((error) => {
                 // TODO Handle no robot found
-                window.alert(error);
+                history.push({
+                    pathname: "/game-select/battle",
+                    username: location.username,
+                    purpose:  "waiting"
+                });
             })
     }
 

--- a/src/components/WaitingQueue.js
+++ b/src/components/WaitingQueue.js
@@ -16,7 +16,11 @@ function WaitingQueue() {
   const [userQueue, setUserQueue] = useState([]);
 
   setInterval(() => {
-    setUserQueue(signallingServer.updatedQueueMessage.updatedQueue);
+    setUserQueue(
+      signallingServer.updatedQueueMessage
+        ? signallingServer.updatedQueueMessage.updatedQueue
+        : []
+    );
   }, 1000);
 
   return (

--- a/src/components/WaitingQueue.js
+++ b/src/components/WaitingQueue.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 
 import "./Battle.css";
 import "../common/Animations.css";
@@ -15,13 +15,16 @@ function updateQueue(userQueue) {
 function WaitingQueue() {
   const [userQueue, setUserQueue] = useState([]);
 
-  setInterval(() => {
-    setUserQueue(
-      signallingServer.updatedQueueMessage
-        ? signallingServer.updatedQueueMessage.updatedQueue
-        : []
-    );
-  }, 1000);
+  useEffect(() => {
+    setInterval(() => {
+      setUserQueue(
+        signallingServer.updatedQueueMessage
+          ? signallingServer.updatedQueueMessage.updatedQueue
+          : []
+      );
+    }, 1000);
+  }, [])
+  
 
   return (
     <div className="queue-container">

--- a/src/components/WaitingQueue.js
+++ b/src/components/WaitingQueue.js
@@ -1,28 +1,31 @@
-import React, { useContext } from 'react';
+import React, { useState } from "react";
 
 import "./Battle.css";
 import "../common/Animations.css";
+import signallingServer from "../api/SignallingServer.js";
 
 function updateQueue(userQueue) {
-    return (
-        userQueue.map((name) => (
-            <span key={userQueue.indexOf(name) + 1}>{userQueue.indexOf(name) + 1}. {name}</span>
-        ))
-    );
+  return userQueue.map((name) => (
+    <span key={userQueue.indexOf(name) + 1}>
+      {userQueue.indexOf(name) + 1}. {name}
+    </span>
+  ));
 }
 
 function WaitingQueue() {
-    //const [userQueue] = useState(useContext(GlobalVals).userBattleQueue);
+  const [userQueue, setUserQueue] = useState([]);
 
-    return (
-        <div className="queue-container">
-            <h3 align="center">Waiting Queue</h3>
-            <hr />
-            <div className="queue-scroll-container">
-                { }
-            </div>
-        </div>
-    );
+  setInterval(() => {
+    setUserQueue(signallingServer.updatedQueueMessage.updatedQueue);
+  }, 1000);
+
+  return (
+    <div className="queue-container">
+      <h3 align="center">Waiting Queue</h3>
+      <hr />
+      <div className="queue-scroll-container">{updateQueue(userQueue)}</div>
+    </div>
+  );
 }
 
 export default WaitingQueue;


### PR DESCRIPTION
<div align="center">

# Feat/update-queue
**This pull request attempts to do two main things:**

- Update the waiting queue once users join
- Route waiting users to the Battle.js page without the video stream
</div>
<hr />

## Update the waiting queue once users join

First, changes in src/api/SignallingServer.js:

- set up updatedQueueMessage = undefined
- update updatedQueueMessage whenever signalling server receives a message with type "update-queue
- create getQueue method to access updatedQueueMessage.updatedQueue when called

Second, changes in changes in src/components/WaitingQueue.js:

- create setInterval function to see if any changes in the queue every 1 second
- If updatedQueue is empty or undefined, just return an empty queue
- Otherwise, map queue to JSX that are presentable in Waiting Queue

And, done!

## Route waiting users to the Battle.js page without the video stream

First, changes in src/components/GameSelect.js:

- if findRobot succeeds, push history.purpose as "playing"
- if findRobot fails, push history.purpose as "waiting"

Second, changes in src/components/Battle.js:

- if history.purpose === "waiting", don't start the video stream. Just show the placeholder.

And, done!

<hr />

Future work:

- Update history.purpose once first in queue
- Ensure waiting members cannot use keyboard
- Perhaps create separate waiting room?



