### PR TITLE
Stop keyboard callback once done playing

### DIFF
--- a/src/components/Battle.js
+++ b/src/components/Battle.js
@@ -40,6 +40,9 @@ function Battle(props) {
       
       // Create timeout to remove user once user has played for 30s
       setTimeout(() => {
+        // Stop keyboard controller
+        keyboardController.stop()
+
         // Disconnect from robot
         signallingServer._send({
           type: "leave",


### PR DESCRIPTION
This fix should stop receiving keyboard inputs from the user once the user is done playing.